### PR TITLE
Specify both flag and value in container args for bool params of slicer CLIs

### DIFF
--- a/girder_item_tasks/cli_parser.py
+++ b/girder_item_tasks/cli_parser.py
@@ -120,11 +120,7 @@ def parseSlicerCliXml(fd):
     for param in inputOpts:
         name = param.flag or param.longflag
         info['inputs'].append(ioSpec(name, param, True))
-
-        if param.typ == 'boolean':
-            info['args'].append('$flag{%s}' % name)
-        else:
-            info['args'].append('%s=$input{%s}' % (name, name))
+        info['args'].append('%s=$input{%s}' % (name, name))
 
     for param in outputOpts:
         name = param.flag or param.longflag

--- a/plugin_tests/tasks_test.py
+++ b/plugin_tests/tasks_test.py
@@ -496,7 +496,8 @@ class TasksTest(base.TestCase):
                 '--MinimumRadius=$input{--MinimumRadius}',
                 '--MinimumSphereActivity=$input{--MinimumSphereActivity}',
                 '--MinimumSphereDistance=$input{--MinimumSphereDistance}',
-                '--SpheresPerPhantom=$input{--SpheresPerPhantom}', '$flag{--StrictSorting}',
+                '--SpheresPerPhantom=$input{--SpheresPerPhantom}',
+                '--StrictSorting=$input{--StrictSorting}',
                 '--DetectedPoints=$output{--DetectedPoints}'
             ],
             'inputs': [{


### PR DESCRIPTION
Currently, only flag is being passed which results in an error within ctk_cli that does argument parsing based on the XML spec for Slicer CLIs.

ctk_cli expects both flag and value to be specified for optional boolean parameters while running Slicer CLIs through the command line.

This same fix was also [made](https://github.com/girder/girder/pull/2895) in the `2.x-maintenance` branch of girder.
